### PR TITLE
Created plugins to optimize css variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
 	"main": "index.js",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build",
+		"build": "vite build && pnpm compress:css",
+		"compress:css": "zxpp ./scripts/cssCompress.ts --dir ./dist/assets",
+		"preview": "vite preview",
 		"lint": "eslint .",
 		"lint:fix": "pnpm lint --fix",
 		"format": "prettier --write **/*.{ts,tsx,js,jsx,json,yaml,yml,css,scss,sass}",
@@ -26,10 +28,13 @@
 		"eslint": "^8.23.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-jsx-a11y": "^6.6.1",
+		"postcss": "^8.4.16",
 		"prettier": "^2.7.1",
 		"sass": "^1.54.5",
 		"typescript": "^4.8.2",
-		"vite": "^3.0.9"
+		"vite": "^3.0.9",
+		"zx": "2.0.0",
+		"zxpp": "^0.2.1"
 	},
 	"dependencies": {
 		"@fontsource/inter": "^4.5.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ specifiers:
   eslint-config-prettier: ^8.5.0
   eslint-plugin-jsx-a11y: ^6.6.1
   js-cookie: ^3.0.1
+  postcss: ^8.4.16
   prettier: ^2.7.1
   pxth: ^0.6.0
   react: ^18.2.0
@@ -29,6 +30,8 @@ specifiers:
   typescript: ^4.8.2
   vite: ^3.0.9
   yup: ^0.32.11
+  zx: 2.0.0
+  zxpp: ^0.2.1
 
 dependencies:
   '@fontsource/inter': 4.5.12
@@ -52,10 +55,13 @@ devDependencies:
   eslint: 8.23.0
   eslint-config-prettier: 8.5.0_eslint@8.23.0
   eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.0
+  postcss: 8.4.16
   prettier: 2.7.1
   sass: 1.54.5
   typescript: 4.8.2
   vite: 3.0.9_5ucq45u4fx45ovxllxrdatrwc4_sass@1.54.5
+  zx: 2.0.0
+  zxpp: 0.2.1
 
 packages:
 
@@ -340,6 +346,20 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
+  /@esbuild-plugins/node-resolve/0.1.4_esbuild@0.14.54:
+    resolution: {integrity: sha512-haFQ0qhxEpqtWWY0kx1Y5oE3sMyO1PcoSiWEPrAw6tm/ZOOLXjSs6Q+v1v9eyuVF0nNt50YEvrcrvENmyoMv5g==}
+    peerDependencies:
+      esbuild: '*'
+    dependencies:
+      '@types/resolve': 1.20.2
+      debug: 4.3.4
+      esbuild: 0.14.54
+      escape-string-regexp: 4.0.0
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@esbuild/linux-loong64/0.14.54:
     resolution: {integrity: sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==}
     engines: {node: '>=12'}
@@ -604,6 +624,12 @@ packages:
       - supports-color
     dev: true
 
+  /@types/fs-extra/9.0.13:
+    resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
+    dependencies:
+      '@types/node': 18.7.13
+    dev: true
+
   /@types/js-cookie/3.0.2:
     resolution: {integrity: sha512-6+0ekgfusHftJNYpihfkMu8BWdeHs9EOJuGcSofErjstGPfPGEu9yTu4t460lTzzAMl2cM5zngQJqPMHbbnvYA==}
     dev: true
@@ -619,6 +645,21 @@ packages:
   /@types/lodash/4.14.184:
     resolution: {integrity: sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==}
     dev: false
+
+  /@types/minimist/1.2.2:
+    resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
+    dev: true
+
+  /@types/node-fetch/2.6.2:
+    resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
+    dependencies:
+      '@types/node': 18.7.13
+      form-data: 3.0.1
+    dev: true
+
+  /@types/node/16.11.56:
+    resolution: {integrity: sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A==}
+    dev: true
 
   /@types/node/18.7.13:
     resolution: {integrity: sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==}
@@ -648,6 +689,10 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.0
+    dev: true
+
+  /@types/resolve/1.20.2:
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
   /@types/scheduler/0.16.2:
@@ -883,6 +928,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /array-union/3.0.1:
+    resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /array-uniq/1.0.3:
     resolution: {integrity: sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==}
     engines: {node: '>=0.10.0'}
@@ -910,6 +960,10 @@ packages:
 
   /ast-types-flow/0.0.7:
     resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
+    dev: true
+
+  /asynckit/0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     dev: true
 
   /axe-core/4.4.3:
@@ -1050,6 +1104,13 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
+  /combined-stream/1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: true
+
   /concat-map/0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
@@ -1137,6 +1198,11 @@ packages:
     dependencies:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
+    dev: true
+
+  /delayed-stream/1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
     dev: true
 
   /dir-glob/2.2.2:
@@ -1835,6 +1901,24 @@ packages:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
 
+  /form-data/3.0.1:
+    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: true
+
+  /fs-extra/10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      graceful-fs: 4.2.10
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
@@ -1937,6 +2021,18 @@ packages:
       ignore: 5.2.0
       merge2: 1.4.1
       slash: 3.0.0
+    dev: true
+
+  /globby/12.2.0:
+    resolution: {integrity: sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      array-union: 3.0.1
+      dir-glob: 3.0.1
+      fast-glob: 3.2.11
+      ignore: 5.2.0
+      merge2: 1.4.1
+      slash: 4.0.0
     dev: true
 
   /globby/7.1.1:
@@ -2160,6 +2256,10 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
+  /is-url/1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
+    dev: true
+
   /is-weakref/1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
@@ -2218,6 +2318,14 @@ packages:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
     hasBin: true
+    dev: true
+
+  /jsonfile/6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.0
+    optionalDependencies:
+      graceful-fs: 4.2.10
     dev: true
 
   /jsx-ast-utils/3.3.3:
@@ -2318,6 +2426,18 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /mime-db/1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /mime-types/2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: true
+
   /min-indent/1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -2357,6 +2477,18 @@ packages:
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
+
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
     dev: true
 
   /node-releases/2.0.6:
@@ -2813,6 +2945,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /slash/4.0.0:
+    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
+    engines: {node: '>=12'}
+    dev: true
+
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
@@ -2957,6 +3094,10 @@ packages:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
     dev: false
 
+  /tr46/0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: true
+
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
@@ -3017,6 +3158,11 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
+  /universalify/2.0.0:
+    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
+    engines: {node: '>= 10.0.0'}
+    dev: true
+
   /update-browserslist-db/1.0.5_browserslist@4.21.3:
     resolution: {integrity: sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==}
     hasBin: true
@@ -3069,6 +3215,17 @@ packages:
       fsevents: 2.3.2
     dev: true
     patched: true
+
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: true
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: true
 
   /which-boxed-primitive/1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -3123,3 +3280,54 @@ packages:
       property-expr: 2.0.5
       toposort: 2.0.2
     dev: false
+
+  /zx/2.0.0:
+    resolution: {integrity: sha512-OF8YvqseMMmtDaASqO+8+0/tJZvykLK0hX9YBAaRO9l7Hc+YjNKjpgJTjrmncgEURoyDr9Ln4r/qBtEuDNZstg==}
+    engines: {node: '>= 14.8.0'}
+    hasBin: true
+    dependencies:
+      '@types/fs-extra': 9.0.13
+      '@types/minimist': 1.2.2
+      '@types/node': 16.11.56
+      '@types/node-fetch': 2.6.2
+      chalk: 4.1.2
+      fs-extra: 10.1.0
+      minimist: 1.2.6
+      node-fetch: 2.6.7
+      which: 2.0.2
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /zx/2.1.0:
+    resolution: {integrity: sha512-7mCJ92ev894l94w5aXkdQoZ9iE6qXERLMPp/uMhTumGKtyhvN8tWprqFFHiXGS/31HxEy1NtNd9NHmYjGHd85A==}
+    engines: {node: '>= 14.8.0'}
+    hasBin: true
+    dependencies:
+      '@types/fs-extra': 9.0.13
+      '@types/minimist': 1.2.2
+      '@types/node': 16.11.56
+      '@types/node-fetch': 2.6.2
+      chalk: 4.1.2
+      fs-extra: 10.1.0
+      globby: 12.2.0
+      minimist: 1.2.6
+      node-fetch: 2.6.7
+      which: 2.0.2
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /zxpp/0.2.1:
+    resolution: {integrity: sha512-jPgpRbdRCrMiQ36Q00zpJyB2L0gfHMThWmcBcHlny3zCVX2YKHCTflD/QJY9Rxm5+gS7SaI0ge1uyYOIBTfSUg==}
+    engines: {node: '>=14.8.0'}
+    hasBin: true
+    dependencies:
+      '@esbuild-plugins/node-resolve': 0.1.4_esbuild@0.14.54
+      esbuild: 0.14.54
+      is-url: 1.2.4
+      zx: 2.1.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true

--- a/postcss/.eslintrc
+++ b/postcss/.eslintrc
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"@typescript-eslint/naming-convention": "off"
+	}
+}

--- a/postcss/inlineCssVariables.ts
+++ b/postcss/inlineCssVariables.ts
@@ -1,0 +1,139 @@
+import { PluginCreator } from 'postcss';
+import { getCssVariableRegex, isVisited, makeVisitable, visit } from './shared';
+
+const incrementCounter = (map: Map<string, number>, variableName: string) => {
+	const currentCount = map.get(variableName) ?? 0;
+	map.set(variableName, currentCount + 1);
+};
+
+const getCounter = (map: Map<string, number>, variableName: string) =>
+	map.get(variableName) ?? 0;
+
+class VariableInliner {
+	private variableDeclarationMap: Map<string, number>;
+	private variableUsageMap: Map<string, number>;
+	private variableValueMap: Map<string, string>;
+
+	public constructor() {
+		this.variableDeclarationMap = new Map();
+		this.variableUsageMap = new Map();
+		this.variableValueMap = new Map();
+	}
+
+	public registerDeclaration = (variableName: string, value: string) => {
+		this.variableValueMap.set(variableName, value);
+		incrementCounter(this.variableDeclarationMap, variableName);
+	};
+
+	public registerUsage = (variableName: string) => {
+		incrementCounter(this.variableUsageMap, variableName);
+	};
+
+	public shouldInline = (variableName: string) => {
+		const variableValue = this.getValue(variableName);
+		const usageCount = getCounter(this.variableUsageMap, variableName);
+		const declarationCount = getCounter(
+			this.variableDeclarationMap,
+			variableName,
+		);
+
+		// Strip unused variables.
+		if (usageCount === 0) {
+			return true;
+		}
+
+		// Cannot inline css variables that have multiple declarations.
+		if (declarationCount > 1) {
+			return false;
+		}
+
+		// Check how much space will be used if keep variable.
+		const currentLength =
+			`var(${variableName})`.length * usageCount +
+			`${variableName}:${variableValue}`.length;
+		// Check how much space will be used when inlined.
+		const possibleLength = variableValue.length * usageCount;
+
+		return possibleLength < currentLength;
+	};
+
+	public getValue = (variableName: string) => {
+		const variableValue = this.variableValueMap.get(variableName);
+
+		if (variableValue === undefined) {
+			throw new Error(`Unknown variable ${variableName} received.`);
+		}
+
+		return variableValue;
+	};
+}
+
+const plugin: PluginCreator<{}> = () => {
+	const inliner = new VariableInliner();
+	let inlinedVariablesCounter = 0;
+
+	return {
+		postcssPlugin: 'Inline css variables plugin',
+		Root: (rootNode) => {
+			const visitable = makeVisitable(rootNode);
+			if (isVisited(visitable)) {
+				return;
+			}
+			visit(visitable);
+
+			rootNode.walkDecls((declaration) => {
+				if (declaration.prop.startsWith('--')) {
+					inliner.registerDeclaration(
+						declaration.prop,
+						declaration.value,
+					);
+				}
+
+				if (declaration.value.includes('var(--')) {
+					const variableMatches = declaration.value.matchAll(
+						getCssVariableRegex(),
+					);
+
+					for (const [, variableName] of variableMatches) {
+						inliner.registerUsage(variableName);
+					}
+				}
+			});
+		},
+		Declaration: (declaration) => {
+			const visitable = makeVisitable(declaration);
+			if (isVisited(visitable)) {
+				return;
+			}
+			visit(visitable);
+
+			if (
+				declaration.prop.startsWith('--') &&
+				inliner.shouldInline(declaration.prop)
+			) {
+				++inlinedVariablesCounter;
+				declaration.remove();
+
+				return;
+			}
+
+			if (declaration.value.includes('var(--')) {
+				declaration.value = declaration.value.replace(
+					getCssVariableRegex(),
+					(source, variableName) => {
+						if (inliner.shouldInline(variableName)) {
+							return inliner.getValue(variableName);
+						}
+						return source;
+					},
+				);
+			}
+		},
+		OnceExit() {
+			console.log(`Inlined ${inlinedVariablesCounter} variables`);
+		},
+	};
+};
+plugin.postcss = true;
+
+export default plugin;

--- a/postcss/optimizeCssVariables.ts
+++ b/postcss/optimizeCssVariables.ts
@@ -1,0 +1,70 @@
+import { Declaration, PluginCreator } from 'postcss';
+import { getCssVariableRegex, isVisited, makeVisitable, visit } from './shared';
+
+class UniqueVariableNameGenerator {
+	private readonly alphabet =
+		'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	private variablesMap: Map<string, string>;
+	private counter = 0;
+
+	public constructor() {
+		this.variablesMap = new Map();
+	}
+
+	private generateUniqueVariableName = (): string => {
+		let variableName = '';
+		let variableIndex = this.counter;
+		do {
+			variableName += this.alphabet[variableIndex % this.alphabet.length];
+			variableIndex = Math.floor(variableIndex / this.alphabet.length);
+		} while (variableIndex > 0);
+
+		++this.counter;
+
+		return `--${variableName}`;
+	};
+
+	public getCompressedVariableName = (variableName: string): string => {
+		let compressedVariableName = this.variablesMap.get(variableName);
+		if (compressedVariableName === undefined) {
+			compressedVariableName = this.generateUniqueVariableName();
+			this.variablesMap.set(variableName, compressedVariableName);
+		}
+
+		return compressedVariableName;
+	};
+}
+
+const plugin: PluginCreator<{}> = () => {
+	const namesGenerator = new UniqueVariableNameGenerator();
+
+	return {
+		postcssPlugin: 'CSS variable name compression',
+		Declaration: (declaration: Declaration) => {
+			const visitable = makeVisitable(declaration);
+			if (isVisited(visitable)) {
+				return;
+			}
+			visit(visitable);
+
+			if (declaration.prop.startsWith('--')) {
+				declaration.prop = namesGenerator.getCompressedVariableName(
+					declaration.prop,
+				);
+			}
+
+			if (declaration.value.includes('var(--')) {
+				declaration.value = declaration.value.replace(
+					getCssVariableRegex(),
+					(_, variableName) =>
+						`var(${namesGenerator.getCompressedVariableName(
+							variableName,
+						)})`,
+				);
+			}
+		},
+	};
+};
+plugin.postcss = true;
+
+export default plugin;

--- a/postcss/shared.ts
+++ b/postcss/shared.ts
@@ -1,0 +1,21 @@
+const visited = Symbol('visited');
+
+export type Visitable<T> = T & Record<typeof visited, boolean>;
+
+export const makeVisitable = <T>(value: T): Visitable<T> => {
+	if (!(visited in value)) {
+		(value as Visitable<T>)[visited] = false;
+	}
+
+	return value as Visitable<T>;
+};
+
+export const isVisited = <T>(visitable: Visitable<T>): boolean => {
+	return visitable[visited];
+};
+
+export const visit = <T>(visitable: Visitable<T>) => {
+	visitable[visited] = true;
+};
+
+export const getCssVariableRegex = () => /var\(\s*(--[\w-]+)\s*\)/g;

--- a/scripts/.eslintrc
+++ b/scripts/.eslintrc
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"unicorn/prefer-node-protocol": "off"
+	}
+}

--- a/scripts/cssCompress.ts
+++ b/scripts/cssCompress.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env zxpp
+
+/// <reference types="zx" />
+
+import { readdir, readFile, writeFile } from 'fs/promises';
+import path from 'path';
+import postcss from 'postcss';
+import inlineVariablesPlugin from '../postcss/inlineCssVariables';
+
+const main = async () => {
+	if (!argv.dir) {
+		throw new Error('"dir" argument is required');
+	}
+
+	const direns = await readdir(argv.dir);
+	const cssFilename = direns.find((value) => /\.css$/.test(value));
+
+	if (!cssFilename) {
+		throw new Error('Cannot find css stylesheet in given directory.');
+	}
+
+	const cssContentBuffer = await readFile(path.join(argv.dir, cssFilename));
+	const cssContent = cssContentBuffer.toString();
+	const result = await postcss([inlineVariablesPlugin()]).process(
+		cssContent,
+		{
+			from: undefined,
+		},
+	);
+
+	await writeFile(path.join(argv.dir, cssFilename), result.css);
+};
+
+try {
+	await main();
+	console.log('CSS stylesheet optimized successfully');
+} catch (error) {
+	console.error('Failed to optimize CSS stylesheet. Reason:\n', error);
+}

--- a/src/styles/Input.module.scss
+++ b/src/styles/Input.module.scss
@@ -2,7 +2,7 @@
 
 .field {
 	--field-color-surface: var(--app-color-surface-field);
-	--field-color-text: var(--app-color-text-body);
+	--field-color-text: var(--app-color-text-default);
 
 	color: var(--field-color-text);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,53 @@
+import { createHash } from 'node:crypto';
 import svgrPlugin from '@honkhonk/vite-plugin-svgr';
 import reactPlugin from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, UserConfig } from 'vite';
+import optimizeCssVariables from './postcss/optimizeCssVariables';
 
-export default defineConfig({
-	appType: 'spa',
-	plugins: [reactPlugin(), svgrPlugin()],
+const classNameStorage = new Map<string, string>();
+
+const hashClassName = (inputClassName: string, filename: string) => {
+	const key = `${filename}:${inputClassName}`;
+	const hash = createHash('md5').update(key).digest('hex').slice(0, 6);
+
+	if (classNameStorage.has(hash) && classNameStorage.get(hash) !== key) {
+		throw new Error(
+			`ClassName hash collision: ${key} and ${classNameStorage.get(
+				hash,
+			)!}`,
+		);
+	}
+
+	classNameStorage.set(hash, key);
+
+	return '_' + hash;
+};
+
+export default defineConfig((environment) => {
+	const sharedOptions: UserConfig = {
+		appType: 'spa',
+		plugins: [reactPlugin(), svgrPlugin()],
+	};
+
+	if (environment.mode === 'production') {
+		return {
+			...sharedOptions,
+			plugins: [...sharedOptions.plugins!],
+			build: {
+				cssCodeSplit: false,
+			},
+			css: {
+				postcss: {
+					plugins: [optimizeCssVariables()],
+				},
+				modules: {
+					generateScopedName(name, filename) {
+						return hashClassName(name, filename);
+					},
+				},
+			},
+		};
+	}
+
+	return sharedOptions;
 });


### PR DESCRIPTION
Replaced class names to their hash in production.

Created 2 postcss plugins:
1. Compress variable names - renames all variables into shorter variants.
2. Inline CSS variables - the plugin throws out unused variables and inlines those variables, which have 1 declaration and it is helpful to inline them because that will reduce CSS bundle size.

The CSS bundle was reduced by 22%, after applying these plugins.